### PR TITLE
Make the crate `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ homepage = "https://github.com/murarth/assert_matches"
 repository = "https://github.com/murarth/assert_matches"
 
 keywords = ["assert", "match", "pattern"]
+categories = ["no-std"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! [`debug_assert_matches!`]: macro.debug_assert_matches.html
 
 #![deny(missing_docs)]
+#![cfg_attr(no_std, not(test))]
 
 /// Asserts that an expression matches a given pattern.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! [`debug_assert_matches!`]: macro.debug_assert_matches.html
 
 #![deny(missing_docs)]
-#![cfg_attr(no_std, not(test))]
+#![cfg_attr(not(test), no_std)]
 
 /// Asserts that an expression matches a given pattern.
 ///


### PR DESCRIPTION
Removes dependency on `std`, making it possible to use this crate in a `no_std` environment.