### PR TITLE
Use `local_inner_macros` to resolve `assert_matches!` within `$crate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,13 +129,19 @@ macro_rules! assert_matches {
 /// See the macro [`assert_matches!`] documentation for more information.
 ///
 /// [`assert_matches!`]: macro.assert_matches.html
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! debug_assert_matches {
     ( $($tt:tt)* ) => { {
-        if cfg!(debug_assertions) {
+        if _assert_matches_cfg!(debug_assertions) {
             assert_matches!($($tt)*);
         }
     } }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _assert_matches_cfg {
+    ( $($tt:tt)* ) => { cfg!($($tt)*) }
 }
 
 #[cfg(test)]

--- a/tests/selective_import1.rs
+++ b/tests/selective_import1.rs
@@ -1,0 +1,9 @@
+#[macro_use(assert_matches)]
+extern crate assert_matches;
+
+#[test]
+fn test_assert_succeed() {
+    let a = 42u32;
+
+    assert_matches!(a, 42);
+}

--- a/tests/selective_import2.rs
+++ b/tests/selective_import2.rs
@@ -1,0 +1,9 @@
+#[macro_use(debug_assert_matches)]
+extern crate assert_matches;
+
+#[test]
+fn test_assert_succeed() {
+    let a = 42u32;
+
+    debug_assert_matches!(a, 42);
+}


### PR DESCRIPTION
This fixes errors when using `debug_assert_matches!` via Rust 2018 style macro imports like `use assert_matches::debug_assert_matches;`.

```
error: cannot find macro `assert_matches` in this scope
   --> redacted.rs:573:5
    |
573 | /     debug_assert_matches!(
574 | |         task.st.read(&*lock),
575 | |         (task::TaskSt::Running | task::TaskSt::Waiting)
576 | |     );
    | |______^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

Related issue: https://github.com/rust-lang-nursery/lazy-static.rs/pull/107
